### PR TITLE
Fix several gameplay issues

### DIFF
--- a/fallitem.py
+++ b/fallitem.py
@@ -19,7 +19,7 @@ import pygame
 
 class FallItem:
 
-    def __init__(self, x, y, flip, speed, path_length, type_="spike"):
+    def __init__(self, x, y, flip, path_length, type_="spike"):
         self.x = x
         self.initial = y
 
@@ -39,12 +39,11 @@ class FallItem:
 
         self.gameDisplay = pygame.display.get_surface()
 
-        self.speed = speed
         self.path_length = path_length
 
-    def update(self):
+    def update(self, fallitem_speed):
         self.draw()
-        self.y -= self.speed
+        self.y -= fallitem_speed
         if self.y < (self.initial - self.path_length):
             return True
         return False

--- a/game.py
+++ b/game.py
@@ -75,7 +75,7 @@ class Game:
             raise Exception("Incorrect game mode")
 
         if len(rows) == 1:
-            self.generator.generate(self.speed)
+            self.generator.generate()
 
         self.spike_spawn_delay = ((self.display_rect.height / 2)
                                   / self.speed) * 20
@@ -148,7 +148,7 @@ class Game:
                             self.guys[i].move()
 
             # Assign speed as per score
-            self.speed = (self.base_speed * self.speed_multiplier) + self.score // 8
+            self.speed = self.base_speed + self.score // 8
             self.spike_spawn_delay = ((self.display_rect.height / 2)
                                       / self.speed) * 18
 
@@ -157,15 +157,16 @@ class Game:
 
             # Generate spikes and increase score
             if self.last_spawned + self.spike_spawn_delay < pygame.time.get_ticks():
-                self.generator.generate(self.speed)
+                self.generator.generate()
                 self.score += 1 * self.score_multiplier
-                self.play_sound("score")
+                if int(self.score) == self.score:
+                    self.play_sound("score")
                 self.last_spawned = pygame.time.get_ticks()
 
             self.show_score()
 
             # updates
-            if self.generator.update(self.guys):
+            if self.generator.update(self.speed, self.guys):
                 # returns true if player is dead
                 return int(self.score)
             for guy in self.guys:

--- a/game.py
+++ b/game.py
@@ -159,7 +159,8 @@ class Game:
                             self.guys[i].move()
 
             # Assign speed as per score
-            self.speed = self.base_speed + self.score // 8
+            if self.speed < self.base_speed * 2:
+                self.speed = self.base_speed + self.score // 12
             self.spike_spawn_delay = ((self.display_rect.height / 2)
                                       / self.speed) * 18
 

--- a/game.py
+++ b/game.py
@@ -124,8 +124,19 @@ class Game:
         return coordinates  # Array of [top-left coords, bottom-right coords]
 
     def show_score(self):
-        scores = self.font1.render(str(int(self.score)), 1, (0, 0, 0))
-        self.gameDisplay.blit(scores, (200 + 650, 30))
+        scores = self.font1.render(str(int(self.score)), 1, "white")
+        scores_rect = scores.get_rect(
+            midtop=(self.gameDisplay.get_width() / 2, 30)
+        )
+        padding = 10
+        score_bg_rect = pygame.Rect(
+            scores_rect.left - padding,
+            scores_rect.top - padding,
+            scores_rect.width + (2 * padding),
+            scores_rect.height + (2 * padding)
+        )
+        pygame.draw.rect(self.gameDisplay, (27, 37, 47), score_bg_rect, 0, 7)
+        self.gameDisplay.blit(scores, scores_rect)
 
     def play_sound(self, sound_name):
         if not self.config["muted"]:
@@ -163,14 +174,14 @@ class Game:
                     self.play_sound("score")
                 self.last_spawned = pygame.time.get_ticks()
 
-            self.show_score()
-
             # updates
             if self.generator.update(self.speed, self.guys):
                 # returns true if player is dead
                 return int(self.score)
             for guy in self.guys:
                 guy.update()
+
+            self.show_score()
 
             pygame.display.update()
             self.clock.tick(60)

--- a/generator.py
+++ b/generator.py
@@ -32,16 +32,16 @@ class Generator:
         for _ in range(len(self.items_config)):
             self.items.append([])
 
-    def generate(self, speed=7):
+    def generate(self):
         for i, config in enumerate(self.items_config):
             if len(self.items[i]) < config[3]:
                 side = int(randint(0, 1))
                 self.items[i].append(FallItem(config[side][0],
                                             config[side][1],
-                                            side, speed, config[2],
+                                            side, config[2],
                                             type_=self.type))
 
-    def update(self, guys=[]):
+    def update(self, fallitem_speed, guys=[]):
         for i, section_items in enumerate(self.items):
             for j, item in enumerate(section_items):
                 for guy in guys:
@@ -59,6 +59,6 @@ class Generator:
                         del self.items[i][j]
                         return True
                         
-                if item.update():
+                if item.update(fallitem_speed):
                     del self.items[i][j]
         return False


### PR DESCRIPTION
* Fix impossible to overcome spike formation - happens because spikes generated after increased speed catch up to the previously generated spikes (with slower speeds),
  ![1](https://github.com/sugarlabs/make-them-fall-activity/assets/94783049/7f79e169-7b42-41d6-a3c9-5fe20fae0954)

* Fix first fallitem having different speed than the rest of the fallitems in Normal, Nightmare and Cardiac modes when the difficulty is set to easy or hard. First spike/heart would be faster than the rest in easy mode, and slower than the rest in hard mode,
![2](https://github.com/sugarlabs/make-them-fall-activity/assets/94783049/6c10fec0-46af-4ab8-81a1-1007ddc7a1d4)
![3](https://github.com/sugarlabs/make-them-fall-activity/assets/94783049/43519794-e0b5-40df-a8cc-26a023a72293)

* Fix score sound playing twice for each score increment in easy mode,

* Center score display on screen,
![4](https://github.com/sugarlabs/make-them-fall-activity/assets/94783049/5346d5ba-5eab-43b7-9fe4-8c135c4eb175)


* Adjust speed increments to occur after every 12 score points instead of 8,

* Add maximum speed limit to all modes, capped at twice the initial base speed.


@walterbender @chimosky @quozl please review.